### PR TITLE
Add regex and config parsing unit tests + debian/rules fix + add skim to searches + skim unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,15 +3074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-application-services"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
-dependencies = [
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,9 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
- "block2 0.6.2",
  "dispatch2",
- "libc",
  "objc2 0.6.3",
 ]
 
@@ -4085,11 +4074,6 @@ dependencies = [
  "icns",
  "image",
  "lnk",
- "objc2 0.6.3",
- "objc2-app-kit 0.3.2",
- "objc2-application-services",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
  "once_cell",
  "open",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-application-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,7 +3156,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -4084,6 +4095,11 @@ dependencies = [
  "icns",
  "image",
  "lnk",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-application-services",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "open",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "gdk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,6 +4077,7 @@ dependencies = [
  "dirs",
  "emojis",
  "freedesktop-desktop-entry",
+ "fuzzy-matcher",
  "glob",
  "global-hotkey",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,12 +68,3 @@ info_plist_path = "bundling/Info.plist"
 [package.metadata.bundle.osx.info]
 LSUIElement = true
 NSHighResolutionCapable = true
-[target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.3"
-objc2-app-kit = { version = "0.3.2", features = ["NSImage"] }
-objc2-application-services = { version = "0.3.2", default-features = false, features = [
-    "HIServices",
-    "Processes",
-] }
-objc2-core-foundation = "0.3.2"
-objc2-foundation = { version = "0.3.2", features = ["NSString"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,6 @@ windows = { version = "0.58", features = [
 ]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.3"
-objc2-app-kit = { version = "0.3.2", features = ["NSImage"] }
-objc2-application-services = { version = "0.3.2", default-features = false, features = [
-    "HIServices",
-    "Processes",
-] }
-objc2-core-foundation = "0.3.2"
-objc2-foundation = { version = "0.3.2", features = ["NSString"] }
 icns = "0.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -76,3 +68,12 @@ info_plist_path = "bundling/Info.plist"
 [package.metadata.bundle.osx.info]
 LSUIElement = true
 NSHighResolutionCapable = true
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.3"
+objc2-app-kit = { version = "0.3.2", features = ["NSImage"] }
+objc2-application-services = { version = "0.3.2", default-features = false, features = [
+    "HIServices",
+    "Processes",
+] }
+objc2-core-foundation = "0.3.2"
+objc2-foundation = { version = "0.3.2", features = ["NSString"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ regex = "1.12.2"
 lnk = "0.6.3"
 codepage = "0.1.2"
 widestring = "1.2.1"
+fuzzy-matcher = "0.3.7"
 
 [package.metadata.bundle]
 name = "RustCast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ windows = { version = "0.58", features = [
 ]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.3"
+objc2-app-kit = { version = "0.3.2", features = ["NSImage"] }
+objc2-application-services = { version = "0.3.2", default-features = false, features = [
+    "HIServices",
+    "Processes",
+] }
+objc2-core-foundation = "0.3.2"
+objc2-foundation = { version = "0.3.2", features = ["NSString"] }
 icns = "0.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,8 @@ export PATH := $(HOME)/.cargo/bin:$(PATH)
 	dh $@
 
 override_dh_auto_build:
-	cargo build --release --target x86_64-unknown-linux-gnu
+	cargo build --release
 
 override_dh_auto_install:
 	install -d $(CURDIR)/debian/rustcast/usr/bin
-	install -m 755 target/x86_64-unknown-linux-gnu/release/rustcast $(CURDIR)/debian/rustcast/usr/bin/rustcast
+	install -m 755 target/release/rustcast $(CURDIR)/debian/rustcast/usr/bin/rustcast

--- a/src/app/tile/mod.rs
+++ b/src/app/tile/mod.rs
@@ -153,13 +153,13 @@ impl Tile {
         });
         Subscription::batch([
             #[cfg(not(target_os = "linux"))]
-            Subscription::run(handle_hotkeys),
+            Subscription::run(Self::handle_hotkeys),
             #[cfg(target_os = "linux")]
-            Subscription::run(handle_socket),
+            Subscription::run(Self::handle_socket),
             keyboard,
-            Subscription::run(handle_recipient),
-            Subscription::run(handle_hot_reloading),
-            Subscription::run(handle_clipboard_history),
+            Subscription::run(Self::handle_recipient),
+            Subscription::run(Self::handle_hot_reloading),
+            Subscription::run(Self::handle_clipboard_history),
             window::close_events().map(Message::HideWindow),
             keyboard::listen().filter_map(|event| {
                 if let keyboard::Event::KeyPressed { key, modifiers, .. } = event {
@@ -266,190 +266,183 @@ impl Tile {
     /// Restores the frontmost application.
     #[allow(deprecated, unused)]
     pub fn restore_frontmost(&mut self) {
+        #[cfg(target_os = "macos")]
         use objc2_app_kit::NSApplicationActivationOptions;
         #[cfg(target_os = "macos")]
         {
             if let Some(app) = self.frontmost.take() {
                 app.activateWithOptions(NSApplicationActivationOptions::ActivateIgnoringOtherApps);
             }
-        #[cfg(target_os = "macos")]
-        {
-            if let Some(app) = self.frontmost.take() {
-                use objc2_app_kit::NSApplicationActivationOptions;
-
-                app.activateWithOptions(NSApplicationActivationOptions::ActivateIgnoringOtherApps);
-            }
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            if let Some(handle) = self.frontmost {
-                unsafe {
-                    let _ = SetForegroundWindow(handle);
+            #[cfg(target_os = "windows")]
+            {
+                if let Some(handle) = self.frontmost {
+                    unsafe {
+                        let _ = SetForegroundWindow(handle);
+                    }
                 }
             }
         }
     }
-}
 
-/// This is the subscription function that handles hot reloading of the config
-fn handle_hot_reloading() -> impl futures::Stream<Item = Message> {
-    stream::channel(100, async |mut output| {
-        let mut content = fs::read_to_string(
-            std::env::var("HOME").unwrap_or_default() + "/.config/rustcast/config.toml",
-        )
-        .unwrap_or_default();
-
-        let paths = default_app_paths();
-        let mut total_files: usize = paths
-            .par_iter()
-            .map(|dir| count_dirs_in_dir(&dir.to_owned().into()))
-            .sum();
-
-        loop {
-            let current_content = fs::read_to_string(
+    /// This is the subscription function that handles hot reloading of the config
+    fn handle_hot_reloading() -> impl futures::Stream<Item = Message> {
+        stream::channel(100, async |mut output| {
+            let mut content = fs::read_to_string(
                 std::env::var("HOME").unwrap_or_default() + "/.config/rustcast/config.toml",
             )
             .unwrap_or_default();
 
-            let current_total_files: usize = paths
+            let paths = default_app_paths();
+            let mut total_files: usize = paths
                 .par_iter()
-                .map(|dir| count_dirs_in_dir(&dir.to_owned().into()))
+                .map(|dir| Self::count_dirs_in_dir(&dir.to_owned().into()))
                 .sum();
 
-            if current_content != content {
-                content = current_content;
-                output.send(Message::ReloadConfig).await.unwrap();
-            } else if total_files != current_total_files {
-                total_files = current_total_files;
-                output.send(Message::ReloadConfig).await.unwrap();
-            }
+            loop {
+                let current_content = fs::read_to_string(
+                    std::env::var("HOME").unwrap_or_default() + "/.config/rustcast/config.toml",
+                )
+                .unwrap_or_default();
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-}
+                let current_total_files: usize = paths
+                    .par_iter()
+                    .map(|dir| Self::count_dirs_in_dir(&dir.to_owned().into()))
+                    .sum();
 
-fn count_dirs_in_dir(dir: &PathBuf) -> usize {
-    // Read the directory; if it fails, treat as empty
-    let Ok(entries) = fs::read_dir(dir) else {
-        return 0;
-    };
-
-    entries
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .count()
-}
-
-/// This is the subscription function that handles hotkeys for hiding / showing the window
-#[cfg(not(target_os = "linux"))]
-fn handle_hotkeys() -> impl futures::Stream<Item = Message> {
-    stream::channel(100, async |mut output| {
-        tracing::debug!(target: "init", "Initing hotkey event receiver");
-        let receiver = GlobalHotKeyEvent::receiver();
-
-        loop {
-            if let Ok(event) = receiver.recv()
-                && event.state == HotKeyState::Pressed
-            {
-                tracing::debug!(target: "hotkey", "Hotkey press received");
-                output.try_send(Message::HotkeyPressed(event.id)).unwrap();
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-}
-
-#[cfg(target_os = "linux")]
-fn handle_socket() -> impl futures::Stream<Item = Message> {
-    use crate::platform::linux::SOCKET_PATH;
-
-    stream::channel(100, async |mut output| {
-        let clipboard = env::args().any(|arg| arg.trim() == "--cphist");
-        if clipboard {
-            output
-                .try_send(Message::OpenToPage(Page::ClipboardHistory))
-                .unwrap();
-        }
-
-        use std::env;
-
-        use tokio::net::UnixListener;
-
-        let _ = fs::remove_file(SOCKET_PATH);
-        let listener = UnixListener::bind(SOCKET_PATH).unwrap();
-
-        while let Ok((mut stream, _address)) = listener.accept().await {
-            let mut output = output.clone();
-            tokio::spawn(async move {
-                use tokio::io::AsyncReadExt;
-                use tracing::info;
-
-                let mut s = String::new();
-                let _ = stream.read_to_string(&mut s).await;
-                info!("received socket command {s}");
-                if s.trim() == "toggle" {
-                    output.try_send(Message::OpenToPage(Page::Main)).unwrap();
-                } else if s.trim() == "clipboard" {
-                    output
-                        .try_send(Message::OpenToPage(Page::ClipboardHistory))
-                        .unwrap();
+                if current_content != content {
+                    content = current_content;
+                    output.send(Message::ReloadConfig).await.unwrap();
+                } else if total_files != current_total_files {
+                    total_files = current_total_files;
+                    output.send(Message::ReloadConfig).await.unwrap();
                 }
-            });
-        }
-    })
-}
 
-/// This is the subscription function that handles the change in clipboard history
-fn handle_clipboard_history() -> impl futures::Stream<Item = Message> {
-    stream::channel(100, async |mut output| {
-        let mut clipboard = Clipboard::new().unwrap();
-        let mut prev_byte_rep: Option<ClipBoardContentType> = None;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+    }
 
-        loop {
-            let byte_rep = if let Ok(a) = clipboard.get_image() {
-                Some(ClipBoardContentType::Image(a))
-            } else if let Ok(a) = clipboard.get_text() {
-                Some(ClipBoardContentType::Text(a))
-            } else {
-                None
-            };
+    fn count_dirs_in_dir(dir: &PathBuf) -> usize {
+        // Read the directory; if it fails, treat as empty
+        let Ok(entries) = fs::read_dir(dir) else {
+            return 0;
+        };
 
-            if byte_rep != prev_byte_rep
-                && let Some(content) = &byte_rep
-            {
+        entries
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .count()
+    }
+
+    /// This is the subscription function that handles hotkeys for hiding / showing the window
+    #[cfg(not(target_os = "linux"))]
+    fn handle_hotkeys() -> impl futures::Stream<Item = Message> {
+        stream::channel(100, async |mut output| {
+            tracing::debug!(target: "init", "Initing hotkey event receiver");
+            let receiver = GlobalHotKeyEvent::receiver();
+
+            loop {
+                if let Ok(event) = receiver.recv()
+                    && event.state == HotKeyState::Pressed
+                {
+                    tracing::debug!(target: "hotkey", "Hotkey press received");
+                    output.try_send(Message::HotkeyPressed(event.id)).unwrap();
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn handle_socket() -> impl futures::Stream<Item = Message> {
+        use crate::platform::linux::SOCKET_PATH;
+
+        stream::channel(100, async |mut output| {
+            let clipboard = env::args().any(|arg| arg.trim() == "--cphist");
+            if clipboard {
                 output
-                    .send(Message::ClipboardHistory(content.to_owned()))
-                    .await
-                    .ok();
-                prev_byte_rep = byte_rep;
+                    .try_send(Message::OpenToPage(Page::ClipboardHistory))
+                    .unwrap();
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-}
 
-fn handle_recipient() -> impl futures::Stream<Item = Message> {
-    stream::channel(100, async |mut output| {
-        let (sender, mut recipient) = channel(100);
-        let msg = Message::SetSender(ExtSender(sender));
-        tracing::debug!(target: "init", "Sending ExtSender");
-        output.send(msg).await.expect("Sender not sent");
-        loop {
-            let abcd = recipient
-                .try_next()
-                .map(async |msg| {
-                    if let Some(msg) = msg {
-                        output.send(msg).await.unwrap();
+            use std::env;
+
+            use tokio::net::UnixListener;
+
+            let _ = fs::remove_file(SOCKET_PATH);
+            let listener = UnixListener::bind(SOCKET_PATH).unwrap();
+
+            while let Ok((mut stream, _address)) = listener.accept().await {
+                let mut output = output.clone();
+                tokio::spawn(async move {
+                    use tokio::io::AsyncReadExt;
+                    use tracing::info;
+
+                    let mut s = String::new();
+                    let _ = stream.read_to_string(&mut s).await;
+                    info!("received socket command {s}");
+                    if s.trim() == "toggle" {
+                        output.try_send(Message::OpenToPage(Page::Main)).unwrap();
+                    } else if s.trim() == "clipboard" {
+                        output
+                            .try_send(Message::OpenToPage(Page::ClipboardHistory))
+                            .unwrap();
                     }
-                })
-                .ok();
-
-            if let Some(abcd) = abcd {
-                abcd.await;
+                });
             }
-            tokio::time::sleep(Duration::from_nanos(10)).await;
-        }
-    })
+        })
+    }
+
+    /// This is the subscription function that handles the change in clipboard history
+    fn handle_clipboard_history() -> impl futures::Stream<Item = Message> {
+        stream::channel(100, async |mut output| {
+            let mut clipboard = Clipboard::new().unwrap();
+            let mut prev_byte_rep: Option<ClipBoardContentType> = None;
+
+            loop {
+                let byte_rep = if let Ok(a) = clipboard.get_image() {
+                    Some(ClipBoardContentType::Image(a))
+                } else if let Ok(a) = clipboard.get_text() {
+                    Some(ClipBoardContentType::Text(a))
+                } else {
+                    None
+                };
+
+                if byte_rep != prev_byte_rep
+                    && let Some(content) = &byte_rep
+                {
+                    output
+                        .send(Message::ClipboardHistory(content.to_owned()))
+                        .await
+                        .ok();
+                    prev_byte_rep = byte_rep;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+    }
+
+    fn handle_recipient() -> impl futures::Stream<Item = Message> {
+        stream::channel(100, async |mut output| {
+            let (sender, mut recipient) = channel(100);
+            let msg = Message::SetSender(ExtSender(sender));
+            tracing::debug!(target: "init", "Sending ExtSender");
+            output.send(msg).await.expect("Sender not sent");
+            loop {
+                let abcd = recipient
+                    .try_next()
+                    .map(async |msg| {
+                        if let Some(msg) = msg {
+                            output.send(msg).await.unwrap();
+                        }
+                    })
+                    .ok();
+
+                if let Some(abcd) = abcd {
+                    abcd.await;
+                }
+                tokio::time::sleep(Duration::from_nanos(10)).await;
+            }
+        })
+    }
 }

--- a/src/app/tile/mod.rs
+++ b/src/app/tile/mod.rs
@@ -36,6 +36,7 @@ use rayon::prelude::*;
 use tray_icon::TrayIcon;
 
 #[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
 use objc2::rc::Retained;
 #[cfg(target_os = "macos")]
 use objc2_app_kit::NSRunningApplication;
@@ -265,6 +266,12 @@ impl Tile {
     /// Restores the frontmost application.
     #[allow(deprecated, unused)]
     pub fn restore_frontmost(&mut self) {
+        use objc2_app_kit::NSApplicationActivationOptions;
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(app) = self.frontmost.take() {
+                app.activateWithOptions(NSApplicationActivationOptions::ActivateIgnoringOtherApps);
+            }
         #[cfg(target_os = "macos")]
         {
             if let Some(app) = self.frontmost.take() {

--- a/src/app/tile/mod.rs
+++ b/src/app/tile/mod.rs
@@ -3,12 +3,15 @@ pub mod elm;
 pub mod update;
 
 mod search_query;
+mod test;
 
 #[cfg(target_os = "windows")]
 use {
     windows::Win32::Foundation::HWND, windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow,
 };
 
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
 use std::{collections::BTreeMap, fs, ops::Bound, path::PathBuf, time::Duration};
 
 use iced::{
@@ -221,19 +224,30 @@ impl Tile {
     /// function to handle the search query changed event.
     pub fn handle_search_query_changed(&mut self) {
         let query = self.query_lc.clone();
+
         let options = if self.page == Page::Main {
             &self.options
         } else if self.page == Page::EmojiSearch {
             &self.emoji_apps
         } else {
-            &AppIndex::from_apps(vec![])
+            return;
         };
-        let results: Vec<SimpleApp> = options
-            .search_prefix(&query)
-            .map(std::borrow::ToOwned::to_owned)
+
+        let matcher = SkimMatcherV2::default();
+
+        let mut scored_results: Vec<(i64, SimpleApp)> = options
+            .by_name
+            .values()
+            .filter_map(|app| {
+                matcher
+                    .fuzzy_match(&app.alias, &query)
+                    .map(|score| (score, app.clone()))
+            })
             .collect();
 
-        self.results = results;
+        scored_results.sort_by(|a, b| b.0.cmp(&a.0));
+
+        self.results = scored_results.into_iter().map(|(_, app)| app).collect();
     }
 
     // Unused, keeping it for now

--- a/src/app/tile/test.rs
+++ b/src/app/tile/test.rs
@@ -7,9 +7,6 @@ mod tests {
 
     #[test]
     fn test_fuzzy_search_ranking() {
-        let app1 = SimpleApp::new_builtin("Firefox", "firefox", "browser", AppCommand::Display);
-        let app2 = SimpleApp::new_builtin("File Manager", "files", "explorer", AppCommand::Display);
-
         let matcher = SkimMatcherV2::default();
         let query = "ffox";
 

--- a/src/app/tile/test.rs
+++ b/src/app/tile/test.rs
@@ -1,0 +1,21 @@
+#[cfg(test)]
+mod tests {
+    use crate::app::apps::AppCommand;
+    use crate::app::pages::prelude::SimpleApp;
+    use fuzzy_matcher::FuzzyMatcher;
+    use fuzzy_matcher::skim::SkimMatcherV2;
+
+    #[test]
+    fn test_fuzzy_search_ranking() {
+        let app1 = SimpleApp::new_builtin("Firefox", "firefox", "browser", AppCommand::Display);
+        let app2 = SimpleApp::new_builtin("File Manager", "files", "explorer", AppCommand::Display);
+
+        let matcher = SkimMatcherV2::default();
+        let query = "ffox";
+
+        let score_firefox = matcher.fuzzy_match("firefox", query).unwrap_or(0);
+        let score_fileman = matcher.fuzzy_match("files", query).unwrap_or(0);
+
+        assert!(score_firefox > score_fileman);
+    }
+}

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -317,16 +317,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             Task::none()
         }
 
-        Message::SocketMessage(msg) => {
-            if msg == "open" {
-                handle_update(tile, Message::OpenToPage(Page::Main))
-            } else if msg == "clipboard" {
-                handle_update(tile, Message::OpenToPage(Page::ClipboardHistory))
-            } else {
-                Task::none()
-            }
-        }
-
         _ => {
             // TODO: finish this match statement
             // Do nothing for now

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -312,7 +312,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             
             // Length limit for clipboard content list
             if tile.clipboard_content.len() > 50 {
-                tile.clipboard_content.pop()
+                tile.clipboard_content.pop();
             }
             Task::none()
         }

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -10,8 +10,7 @@ use rayon::slice::ParallelSliceMut;
 use crate::app::apps::AppData;
 use crate::app::{
     ArrowKey, DEFAULT_WINDOW_HEIGHT, Message, Move, Page, WINDOW_WIDTH, apps::AppCommand,
-    apps::SimpleApp, default_settings, menubar::menu_icon, tile::AppIndex, tile::Tile,
-    tile::search_query,
+    apps::SimpleApp, default_settings, tile::AppIndex, tile::Tile,
 };
 
 #[cfg(target_os = "macos")]
@@ -306,85 +305,11 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
         }
 
-        Message::SwitchToPage(page) => {
-            tile.page = page;
-            Task::batch([
-                Task::done(Message::ClearSearchQuery),
-                Task::done(Message::ClearSearchResults),
-            ])
-        }
-
-        Message::RunFunction(command) => {
-            command.execute(&tile.config, &tile.query);
-
-            let return_focus_task = match &command {
-                Function::OpenApp(_) | Function::OpenPrefPane | Function::GoogleSearch(_) => {
-                    Task::none()
-                }
-                _ => Task::done(Message::ReturnFocus),
-            };
-
-            if tile.config.buffer_rules.clear_on_enter {
-                window::latest()
-                    .map(|x| x.unwrap())
-                    .map(Message::HideWindow)
-                    .chain(Task::done(Message::ClearSearchQuery))
-                    .chain(return_focus_task)
-            } else {
-                Task::none()
-            }
-        }
-
-        Message::HideWindow(a) => {
-            tile.visible = false;
-            tile.focused = false;
-            tile.page = Page::Main;
-            Task::batch([window::close(a), Task::done(Message::ClearSearchResults)])
-        }
-
-        Message::ReturnFocus => {
-            tile.restore_frontmost();
+        _ => {
+            // TODO: finish this match statement
+            // Do nothing for now
             Task::none()
         }
-
-        Message::FocusTextInput(update_query_char) => {
-            match update_query_char {
-                Move::Forwards(query_char) => {
-                    tile.query += &query_char.clone();
-                    tile.query_lc += &query_char.clone().to_lowercase();
-                }
-                Move::Back => {
-                    tile.query.pop();
-                    tile.query_lc.pop();
-                }
-            }
-            let updated_query = tile.query.clone();
-            Task::batch([
-                operation::focus("query"),
-                window::latest()
-                    .map(|x| x.unwrap())
-                    .map(move |x| Message::SearchQueryChanged(updated_query.clone(), x)),
-            ])
-        }
-
-        Message::WindowFocusChanged(wid, focused) => {
-            tile.focused = focused;
-            if focused {
-                Task::none()
-            } else if cfg!(target_os = "macos") {
-                Task::done(Message::HideWindow(wid)).chain(Task::done(Message::ClearSearchQuery))
-            } else {
-                // linux seems to not wanna unfocus it on start making it not show
-                Task::none()
-            }
-        }
-
-        Message::ClipboardHistory(content) => {
-            tile.clipboard_content.insert(0, content);
-            Task::none()
-        }
-
-        Message::SearchQueryChanged(input, id) => search_query::handle_change(tile, &input, id),
     }
 }
 

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -51,6 +51,8 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 // I do not know so much abt rendering stuff
                 #[cfg(not(target_os = "linux"))]
                 {
+                    use crate::app::menubar::menu_icon;
+
                     tile.tray_icon = Some(menu_icon(
                         #[cfg(not(target_os = "linux"))]
                         tile.hotkey,

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -309,7 +309,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
         Message::ClipboardHistory(text) => {
             tile.clipboard_content.insert(0, text);
-            
+
             // Length limit for clipboard content list
             if tile.clipboard_content.len() > 50 {
                 tile.clipboard_content.pop();

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -307,6 +307,26 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
         }
 
+        Message::ClipboardHistory(text) => {
+            tile.clipboard_content.insert(0, text);
+            
+            // Length limit for clipboard content list
+            if tile.clipboard_content.len() > 50 {
+                tile.clipboard_content.pop()
+            }
+            Task::none();
+        }
+
+        Message::SocketMessage(msg) => {
+            if msg == "open" {
+                handle_update(tile, Message::OpenToPage(Page::Main))
+            } else if msg == "clipboard" {
+                handle_update(tile, Message::OpenToPage(Page::ClipboardHistory))
+            } else {
+                Task::none()
+            }
+        }
+
         _ => {
             // TODO: finish this match statement
             // Do nothing for now

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -314,7 +314,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             if tile.clipboard_content.len() > 50 {
                 tile.clipboard_content.pop()
             }
-            Task::none();
+            Task::none()
         }
 
         Message::SocketMessage(msg) => {

--- a/src/app_finding/linux.rs
+++ b/src/app_finding/linux.rs
@@ -8,7 +8,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     app::{
-        apps::{AppCommand, AppData, SimpleApp},
+        apps::{AppData, SimpleApp},
         tile::elm::default_app_paths,
     },
     config::Config,
@@ -84,9 +84,9 @@ fn get_installed_apps(path: &Path, store_icons: bool) -> Vec<SimpleApp> {
     };
 
     apps.push(SimpleApp::new(
-        &name,
+        name,
         &name.to_lowercase(),
-        &desc,
+        desc,
         AppData::Command {
             command: cmd.to_string(),
             alias: args,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,7 +36,7 @@ fn sys_open(path: &str) {
     #[cfg(target_os = "macos")]
     {
         use objc2_app_kit::NSWorkspace;
-        use objc2_foundation::{NSURL, NSString};
+        use objc2_foundation::{NSString, NSURL};
         unsafe {
             let url = if path.starts_with("http") {
                 NSURL::URLWithString(&NSString::from_str(path))
@@ -87,17 +87,17 @@ impl Function {
             }
 
             Function::OpenWebsite(url) => {
-                let open_url = if url.starts_with("http") {
-                let open_url = if url.starts_with("http") {
-                    url.to_owned()
-                } else {
-                    format!("https://{url}")
+                if url.starts_with("http") {
+                    let open_url = if url.starts_with("http") {
+                        url.to_owned()
+                    } else {
+                        format!("https://{url}")
+                    };
+
+                    // Should never get here without it being validated first
+                    open::that(open_url).unwrap();
                 };
-
-                // Should never get here without it being validated first
-                open::that(open_url).unwrap();
             }
-
             Function::Calculate(expr) => {
                 Clipboard::new()
                     .unwrap()
@@ -117,8 +117,10 @@ impl Function {
             #[cfg(target_os = "macos")]
             Function::OpenPrefPane => {
                 thread::spawn(move || {
-                    let config_path = format!("{}/.config/rustcast/config.toml", 
-                        std::env::var("HOME").unwrap_or_else(|_| "".to_string()));
+                    let config_path = format!(
+                        "{}/.config/rustcast/config.toml",
+                        std::env::var("HOME").unwrap_or_else(|_| "".to_string())
+                    );
                     sys_open(&config_path);
                 });
             }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -87,17 +87,12 @@ impl Function {
             }
 
             Function::OpenWebsite(url) => {
-                if url.starts_with("http") {
-                    let open_url = if url.starts_with("http") {
-                        url.to_owned()
-                    } else {
-                        format!("https://{url}")
-                    };
+                    let open_url = url.to_owned();
 
                     // Should never get here without it being validated first
                     open::that(open_url).unwrap();
-                };
-            }
+                }
+
             Function::Calculate(expr) => {
                 Clipboard::new()
                     .unwrap()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -41,7 +41,7 @@ fn sys_open(path: &str) {
             let url = if path.starts_with("http") {
                 NSURL::URLWithString(&NSString::from_str(path))
             } else {
-                NSURL::fileURLWithPath(&NSString::from_str(path))
+                Some(NSURL::fileURLWithPath(&NSString::from_str(path)))
             };
             if let Some(u) = url {
                 NSWorkspace::sharedWorkspace().openURL(&u);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,7 +7,9 @@ use std::thread;
 
 use arboard::Clipboard;
 #[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
 use objc2_app_kit::NSWorkspace;
+#[cfg(target_os = "macos")]
 #[cfg(target_os = "macos")]
 use objc2_foundation::NSURL;
 
@@ -28,6 +30,29 @@ pub enum Function {
     Calculate(Expr),
     OpenPrefPane,
     Quit,
+}
+
+fn sys_open(path: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2_app_kit::NSWorkspace;
+        use objc2_foundation::{NSURL, NSString};
+        unsafe {
+            let url = if path.starts_with("http") {
+                NSURL::URLWithString(&NSString::from_str(path))
+            } else {
+                NSURL::fileURLWithPath(&NSString::from_str(path))
+            };
+            if let Some(u) = url {
+                NSWorkspace::sharedWorkspace().openURL(&u);
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(path).spawn();
+    }
 }
 
 impl Function {
@@ -63,6 +88,7 @@ impl Function {
 
             Function::OpenWebsite(url) => {
                 let open_url = if url.starts_with("http") {
+                let open_url = if url.starts_with("http") {
                     url.to_owned()
                 } else {
                     format!("https://{url}")
@@ -91,12 +117,9 @@ impl Function {
             #[cfg(target_os = "macos")]
             Function::OpenPrefPane => {
                 thread::spawn(move || {
-                    NSWorkspace::new().openURL(&NSURL::fileURLWithPath(
-                        &objc2_foundation::NSString::from_str(
-                            &(std::env::var("HOME").unwrap_or("".to_string())
-                                + "/.config/rustcast/config.toml"),
-                        ),
-                    ));
+                    let config_path = format!("{}/.config/rustcast/config.toml", 
+                        std::env::var("HOME").unwrap_or_else(|_| "".to_string()));
+                    sys_open(&config_path);
                 });
             }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,14 +2,13 @@
 //! copying to clipboard, etc.
 use std::path::PathBuf;
 use std::process::Command;
-#[cfg(target_os = "macos")]
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::thread;
 
 use arboard::Clipboard;
 #[cfg(target_os = "macos")]
-#[cfg(target_os = "macos")]
 use objc2_app_kit::NSWorkspace;
-#[cfg(target_os = "macos")]
 #[cfg(target_os = "macos")]
 use objc2_foundation::NSURL;
 
@@ -87,11 +86,11 @@ impl Function {
             }
 
             Function::OpenWebsite(url) => {
-                    let open_url = url.to_owned();
+                let open_url = url.to_owned();
 
-                    // Should never get here without it being validated first
-                    open::that(open_url).unwrap();
-                }
+                // Should never get here without it being validated first
+                open::that(open_url).unwrap();
+            }
 
             Function::Calculate(expr) => {
                 Clipboard::new()
@@ -109,7 +108,7 @@ impl Function {
                 }
             },
 
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             Function::OpenPrefPane => {
                 thread::spawn(move || {
                     let config_path = format!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@ mod patterns;
 mod test;
 
 /// The main config struct (effectively the config file's "schema")
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct Config {
     pub toggle_hotkey: String,
@@ -87,7 +87,7 @@ impl Default for Config {
 }
 
 /// The settings you can set for the theme
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct Theme {
     pub text_color: (f32, f32, f32),
@@ -188,7 +188,7 @@ impl Theme {
 /// - `clear_on_hide` is whether the buffer should be cleared when the window is hidden
 /// - `clear_on_enter` is whether the buffer should be cleared when the user presses enter after
 ///   searching
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct Buffer {
     pub clear_on_hide: bool,
@@ -207,7 +207,7 @@ impl Default for Buffer {
 /// Command is the command it will run when the button is clicked
 /// `Icon_path` is the path to an icon, but this is optional
 /// Alias is the text that is used to call this command / search for it
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Shelly {
     command: String,
     icon_path: Option<String>,
@@ -241,7 +241,7 @@ const fn true_f() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")] // so that the type doesn't have to be in PascalCase within the config
 pub enum Logger {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 mod include_patterns;
 mod level;
 mod patterns;
+mod test;
 
 /// The main config struct (effectively the config file's "schema")
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -41,25 +41,15 @@ mod tests {
     #[test]
     fn test_parse_config() {
         use crate::config::Config;
-        use crate::utils::read_config_file;
-        use std::fs;
+        
+        let original_config = Config::default();
 
-        let test_path = std::env::current_dir().unwrap().join("test_config.toml");
+        let toml_string = toml::to_string(&original_config)
+            .expect("Should be able to turn config into a string");
+        
+        let recovered_config: Config = toml::from_str(&toml_string)
+            .expect("Should be able to read that string back into a Config");
 
-        let default_cfg = Config::default();
-        let toml_content = toml::to_string(&default_cfg).expect("Failed to serialize");
-        fs::write(&test_path, toml_content).expect("Failed to write temp file");
-
-        let loaded_result = read_config_file(&test_path);
-
-        let _ = fs::remove_file(&test_path);
-
-        assert!(
-            loaded_result.is_ok(),
-            "The program failed to read its default config from disk!"
-        );
-
-        let loaded_cfg = loaded_result.unwrap();
-        assert_eq!(loaded_cfg.toggle_hotkey, "ALT+SPACE");
+        assert_eq!(original_config, recovered_config);
     }
 }

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -1,0 +1,65 @@
+#[cfg(test)]
+mod tests {
+    use crate::config::include_patterns::Pattern;
+
+    #[test]
+    fn test_regex_path_only() {
+        let input = "/home/user/test";
+
+        let pattern: Pattern = input.parse().unwrap();
+
+        assert_eq!(pattern.path.to_str().unwrap(), "/home/user/test");
+        assert_eq!(pattern.max_depth, 1);
+    }
+
+    #[test]
+    fn test_regex_with_explicit_depth() {
+        let input = "/var/log:5";
+        let pattern: Pattern = input.parse().unwrap();
+
+        assert_eq!(pattern.path.to_str().unwrap(), "/var/log");
+        assert_eq!(pattern.max_depth, 5);
+    }
+
+    #[test]
+    fn test_regex_edge_cases() {
+        let input = "/weird:path:with:colons:10";
+        let pattern: Pattern = input.parse().unwrap();
+
+        assert_eq!(pattern.max_depth, 10);
+        assert!(pattern.path.to_str().unwrap().contains("colons"));
+    }
+
+    #[test]
+    fn test_regex_invalid_depth() {
+        let input = "/etc:abc";
+        let pattern: Pattern = input.parse().unwrap();
+
+        assert_eq!(pattern.max_depth, 1);
+    }
+
+    #[test]
+    fn test_parse_config() {
+        use crate::config::Config;
+        use crate::utils::read_config_file;
+        use std::fs;
+
+        let test_path = std::env::current_dir().unwrap().join("test_config.toml");
+
+        let default_cfg = Config::default();
+        let toml_content = toml::to_string(&default_cfg).expect("Failed to serialize");
+        fs::write(&test_path, toml_content).expect("Failed to write temp file");
+
+        let loaded_result = read_config_file(&test_path);
+
+        let _ = fs::remove_file(&test_path);
+
+        assert!(
+            loaded_result.is_ok(),
+            "The program failed to read its default config from disk!"
+        );
+
+        let loaded_cfg = loaded_result.unwrap();
+        assert_eq!(loaded_cfg.toggle_hotkey, "ALT+SPACE");
+    }
+}

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -41,12 +41,12 @@ mod tests {
     #[test]
     fn test_parse_config() {
         use crate::config::Config;
-        
+
         let original_config = Config::default();
 
-        let toml_string = toml::to_string(&original_config)
-            .expect("Should be able to turn config into a string");
-        
+        let toml_string =
+            toml::to_string(&original_config).expect("Should be able to turn config into a string");
+
         let recovered_config: Config = toml::from_str(&toml_string)
             .expect("Should be able to read that string back into a Config");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,6 @@ fn load_config() -> Config {
             Config::default()
         }
         Ok(config) => {
-            parse_cfg_file(file_path)
-                .inspect_err(|e| {
-                    preinit_logger::warn(&format!(
-                        "Failed to load config with error {e}; using default config"
-                    ));
-                })
-                .unwrap_or_default();
-
             init_loggers(&config);
             config
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::hotkey::init_hotkey_manager;
 #[cfg(target_os = "linux")]
 use crate::hotkey::init_socket;
 
-fn parse_cfg_file(path: impl AsRef<Path>) -> anyhow::Result<Config> {
+pub fn parse_cfg_file(path: impl AsRef<Path>) -> anyhow::Result<Config> {
     let config = read_config_file(path.as_ref());
     if let Err(e) = config {
         return Err(e.context("Failure to parse config"));

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -8,7 +8,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     app::{
-        apps::{AppCommand, AppData, SimpleApp},
+        apps::{AppData, SimpleApp},
         tile::elm::default_app_paths,
     },
     config::Config,
@@ -86,9 +86,9 @@ fn get_installed_apps(path: &Path, store_icons: bool) -> Vec<SimpleApp> {
     };
 
     apps.push(SimpleApp::new(
-        &name,
+        name,
         &name.to_lowercase(),
-        &desc,
+        desc,
         AppData::Command {
             command: cmd.to_string(),
             alias: args,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,9 +8,6 @@ use std::{
 #[cfg(target_os = "macos")]
 use {objc2_app_kit::NSWorkspace, objc2_foundation::NSURL};
 
-#[cfg(target_os = "linux")]
-use crate::platform::linux::get_installed_linux_apps;
-
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 use std::process::Command;
 


### PR DESCRIPTION
This pull request will fix debian/rules to automatically compile Rustcast with the actual host triple instead of a hardcoded `--target x86_64-unknown-linux-gnu` flag. The PR will also add 5 new unit tests in `src/config/test.rs`:

- `test_regex_path_only` - makes sure that `include_patterns` can handle a simple file path (e.g `/home/ferris/rustcast`) without depth being specified (defaults to `1` in that case)
- `test_regex_with_explicit_depth` - same as `test_regex_path_only`, but this time the depth is explicitly specified, thus overriding the default value
- `test_regex_edge_cases` - makes sure that the compiler will not confuse colons in the file path with the colon preceding the depth (for example `this:is:a:pretty:long:path:10`)
- `test_regex_invalid_depth` - makes sure that the compiler will fall back to the default depth of `1` when an invalid depth (non-numerical, such as `:abc`) is supplied
- `test_parse_config` - makes sure the config file can be properly parsed by using the default config to create a temporary file on the user's disk to parse it

This PR will also make the search function use `skim` to make searching faster and less prone to typos leading to no results. This is in response to [#6](https://github.com/rustcast-cross/rustcast-cross/issues/6).